### PR TITLE
Fix operation queue logic to avoid duplicate entries in the operation queue

### DIFF
--- a/src/main/java/com/imagelab/DashboardController.java
+++ b/src/main/java/com/imagelab/DashboardController.java
@@ -39,7 +39,7 @@ public class DashboardController implements Initializable {
 
     private OperatorUIElement<Node> currentlyApplyingOperator;
 
-    private Stack<OperatorUIElement<Node>> appliedOperators;
+    private final Stack<OperatorUIElement<Node>> appliedOperators;
 
     public DashboardController() {
         this.appliedOperators = new Stack<>();
@@ -101,7 +101,14 @@ public class DashboardController implements Initializable {
                 currentlyApplyingOperator.getNode().setLayoutY(relocateY);
                 buildPane.getChildren().add(currentlyApplyingOperator.getNode());
             }
-            this.appliedOperators.push(currentlyApplyingOperator);
+            if (!this.currentlyApplyingOperator.isAddedToOperationQueue()){
+                this.appliedOperators.push(currentlyApplyingOperator);
+                this.currentlyApplyingOperator.setIsAddedToOperationQueue(true);
+                System.out.println(currentlyApplyingOperator.getUiOperatorName()+" has been added to the operation queue");
+            }else{
+                System.out.println("This operator is already in the queue");
+            }
+
             event.setDropCompleted(true);
             event.consume();
         }
@@ -127,6 +134,7 @@ public class DashboardController implements Initializable {
                 true,
                 "imagelab.operator.readImageOpUIElement",
                 "Read Image",
+                false,
                 100d,
                 60d,
                 true);
@@ -139,6 +147,7 @@ public class DashboardController implements Initializable {
                 true,
                 "imagelab.operator.rgbChangeOpUIElement",
                 "RGB Convert",
+                false,
                 100d,
                 60d,
                 true);
@@ -151,6 +160,7 @@ public class DashboardController implements Initializable {
                 true,
                 "imagelab.operator.toGrayScaleOpUIElement",
                 "Grey Scale",
+                false,
                 100d,
                 60d,
                 true);

--- a/src/main/java/com/imagelab/components/OperatorUIElement.java
+++ b/src/main/java/com/imagelab/components/OperatorUIElement.java
@@ -5,7 +5,7 @@ import com.imagelab.components.events.OnUIElementDragDone;
 import javafx.scene.Node;
 
 /**
- *Abstract class related to the operator UI elements
+ * Abstract class related to the operator UI elements
  *
  * @param <T> any node
  */
@@ -13,6 +13,7 @@ public abstract class OperatorUIElement<T extends Node> {
 
     private final String uiOperatorID;
     private final String uiOperatorName;
+    private boolean isAddedToOperationQueue;
 
     /*Events*/
     private final OnUIElementCloneCreated onCloneCreated;
@@ -28,9 +29,10 @@ public abstract class OperatorUIElement<T extends Node> {
 
     private final T node;
 
-    public OperatorUIElement(String uiOperatorID, String uiOperatorName, OnUIElementCloneCreated onCloneCreated, OnUIElementDragDone onDragDone, String stylingID, boolean cloneable, boolean previewOnly, double width, double height) {
+    public OperatorUIElement(String uiOperatorID, String uiOperatorName, boolean isAddedToOperationQueue, OnUIElementCloneCreated onCloneCreated, OnUIElementDragDone onDragDone, String stylingID, boolean cloneable, boolean previewOnly, double width, double height) {
         this.uiOperatorID = uiOperatorID;
         this.uiOperatorName = uiOperatorName;
+        this.isAddedToOperationQueue = isAddedToOperationQueue;
         this.onCloneCreated = onCloneCreated;
         this.onDragDone = onDragDone;
         this.stylingID = stylingID;
@@ -49,6 +51,12 @@ public abstract class OperatorUIElement<T extends Node> {
 
     public String getUiOperatorName() {
         return uiOperatorName;
+    }
+
+    public boolean isAddedToOperationQueue() { return isAddedToOperationQueue; }
+
+    public void setIsAddedToOperationQueue(boolean isAddedToOperationQueue){
+        this.isAddedToOperationQueue = isAddedToOperationQueue;
     }
 
     public OnUIElementCloneCreated getOnCloneCreated() {

--- a/src/main/java/com/imagelab/components/RGBChangeOpUIElement.java
+++ b/src/main/java/com/imagelab/components/RGBChangeOpUIElement.java
@@ -22,10 +22,11 @@ public class RGBChangeOpUIElement extends OperatorUIElement<Button> implements D
                                 boolean cloneable,
                                 String uiOperatorID,
                                 String uiOperatorName,
+                                boolean isAddedToOperationQueue,
                                 double width,
                                 double height,
                                 boolean previewOnly) {
-        super(uiOperatorID, uiOperatorName, onCloneCreated, onDragDone, stylingID, cloneable, previewOnly, width, height);
+        super(uiOperatorID, uiOperatorName, isAddedToOperationQueue, onCloneCreated, onDragDone, stylingID, cloneable, previewOnly, width, height);
     }
 
     /**
@@ -73,6 +74,7 @@ public class RGBChangeOpUIElement extends OperatorUIElement<Button> implements D
                 false,
                 this.getUiOperatorID(),
                 this.getUiOperatorName(),
+                false,
                 this.getWidth(),
                 this.getHeight(),
                 false);

--- a/src/main/java/com/imagelab/components/ReadImageOpUIElement.java
+++ b/src/main/java/com/imagelab/components/ReadImageOpUIElement.java
@@ -27,10 +27,11 @@ public class ReadImageOpUIElement extends OperatorUIElement<Button> implements D
             boolean cloneable,
             String uiOperatorID,
             String uiOperatorName,
+            boolean isAddedToOperationQueue,
             double width,
             double height,
             boolean previewOnly) {
-        super(uiOperatorID, uiOperatorName, onCloneCreated, onDragDone, stylingID, cloneable, previewOnly, width, height);
+        super(uiOperatorID, uiOperatorName, isAddedToOperationQueue, onCloneCreated, onDragDone, stylingID, cloneable, previewOnly, width, height);
     }
 
     /**
@@ -42,7 +43,6 @@ public class ReadImageOpUIElement extends OperatorUIElement<Button> implements D
     @Override
     public void dragDetected(MouseEvent event) {
         System.out.println("Drag detected: ReadImageOpUIElement");
-
         // create new clone
         assert getOnCloneCreated() != null;
         try {
@@ -79,6 +79,7 @@ public class ReadImageOpUIElement extends OperatorUIElement<Button> implements D
                 false,
                 this.getUiOperatorID(),
                 this.getUiOperatorName(),
+                false,
                 this.getWidth(),
                 this.getHeight(),
                 false);

--- a/src/main/java/com/imagelab/components/ToGrayScaleOpUIElement.java
+++ b/src/main/java/com/imagelab/components/ToGrayScaleOpUIElement.java
@@ -21,10 +21,11 @@ public class ToGrayScaleOpUIElement extends OperatorUIElement<Button> implements
                                   boolean cloneable,
                                   String uiOperatorID,
                                   String uiOperatorName,
+                                  boolean isAddedToOperationQueue,
                                   double width,
                                   double height,
                                   boolean previewOnly) {
-        super(uiOperatorID, uiOperatorName, onCloneCreated, onDragDone, stylingID, cloneable, previewOnly, width, height);
+        super(uiOperatorID, uiOperatorName, isAddedToOperationQueue, onCloneCreated, onDragDone, stylingID, cloneable, previewOnly, width, height);
     }
 
     /**
@@ -72,6 +73,7 @@ public class ToGrayScaleOpUIElement extends OperatorUIElement<Button> implements
                 false,
                 this.getUiOperatorID(),
                 this.getUiOperatorName(),
+                false,
                 this.getWidth(),
                 this.getHeight(),
                 false);


### PR DESCRIPTION
## Description
This commit contains fixes for the operation queue logic. Earlier when a user dragged and dropped an element to the build pane and move it in the build pane, the logic added duplicates to the operation order queue. This PR contains a fix for that.

## Type of change 
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Current Status 
<img width="1281" alt="Screenshot 2020-07-21 at 18 47 14" src="https://user-images.githubusercontent.com/23298579/88059707-da7c7d00-cb82-11ea-82af-20eaf2bd4fce.png">