### PR TITLE
Solving checkstyle errors while building by adding pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         </dependency>
     </dependencies>
     <build>
+        <pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -115,5 +116,6 @@
                 </executions>
             </plugin>
         </plugins>
+        </pluginManagement>
     </build>
 </project>


### PR DESCRIPTION
These errors were appearing while building the project with dependencies because pluginManagement weren't in the pom.xml file so I updated it in order not to cause any errors.

![Screenshot 2021-04-12 003645](https://user-images.githubusercontent.com/43797542/114323848-68d8ca80-9b27-11eb-97bb-ce60361bda00.png)


