### PR TITLE
Improve: Box Filter Properties form + remove text fields + add sliders

### DIFF
--- a/src/main/java/com/imagelab/operator/filtering/ApplyBoxFilter.java
+++ b/src/main/java/com/imagelab/operator/filtering/ApplyBoxFilter.java
@@ -115,7 +115,7 @@ public class ApplyBoxFilter extends OpenCVOperator {
                                double pointX, double pointY) {
         // Creating an empty matrix to store the result
         Mat image = new Mat();
-
+        
         // Creating the objects for Size and Point
         Size size = new Size(width, height);
         Point point = new Point(pointX, pointY);

--- a/src/main/java/com/imagelab/view/forms/BoxFilterPropertiesForm.java
+++ b/src/main/java/com/imagelab/view/forms/BoxFilterPropertiesForm.java
@@ -1,9 +1,13 @@
 package com.imagelab.view.forms;
 
 import com.imagelab.operator.filtering.ApplyBoxFilter;
+
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.scene.control.Label;
-import javafx.scene.control.TextField;
+import javafx.scene.control.Slider;
 import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
 
 /**
  * Applying box filter operation related
@@ -16,74 +20,150 @@ public class BoxFilterPropertiesForm extends AbstractPropertiesForm {
      * @param operator - operator which requires this properties form.
      */
     public BoxFilterPropertiesForm(ApplyBoxFilter operator) {
-        //Box Filter tittle container.
+        //Box Filter title container.
         PropertiesFormTitleContainer boxFilterTitleContainer;
         boxFilterTitleContainer = new PropertiesFormTitleContainer("Box Filter Properties");
 
         //Depth
-        VBox depthSizeContainer = new VBox();
-        depthSizeContainer.setPrefWidth(205.0);
-        depthSizeContainer.setSpacing(10);
-        Label lblDepthSize = new Label("Size: depth");
-        TextField depthSizeTextField = new TextField(String.valueOf(50));
-        depthSizeTextField.setPrefSize(205.0, 27.0);
-        //Listener to capture text change.
-        depthSizeTextField.textProperty().addListener((observable, oldValue, newValue) -> {
-            operator.setWidthSize(Double.parseDouble(newValue));
-        });
-        depthSizeContainer.getChildren().addAll(lblDepthSize, depthSizeTextField);
+        VBox depthSliderContainer = new VBox();
+        depthSliderContainer.setPrefWidth(205.0);
+        depthSliderContainer.setSpacing(10);
+        Label lblDepthSlider = new Label("Depth :");
+     
+        Slider depthSlider = new Slider();
+        depthSlider.setMin(0);
+        depthSlider.setMax(100);
+        depthSlider.setValue(50);
+        // enable TickLabels and Tick Marks
+        depthSlider.setShowTickLabels(true);
+        depthSlider.setShowTickMarks(true);
+        depthSlider.setBlockIncrement(10);
+        // Adding Listener to value property.
+        depthSlider.valueProperty().addListener(new ChangeListener<Number>() {
+
+			@Override
+			public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
+				// TODO Auto-generated method stub
+				lblDepthSlider.setText(String.format("Depth : %d units", (int)newValue.doubleValue()));
+				operator.setDepth((int)newValue.doubleValue());
+			}
+        	
+		});
+        depthSliderContainer.getChildren().addAll(lblDepthSlider, depthSlider);
 
         //Size - width.
         VBox widthSizeContainer = new VBox();
         widthSizeContainer.setPrefWidth(205.0);
-        widthSizeContainer.setSpacing(10);
-        Label lblWidthSize = new Label("Size: width");
-        TextField widthSizeTextField = new TextField(String.valueOf(45.0));
-        widthSizeTextField.setPrefSize(205.0, 27.0);
-        //Listener to capture text change.
-        widthSizeTextField.textProperty().addListener((observable, oldValue, newValue) -> {
-            operator.setWidthSize(Double.parseDouble(newValue));
-        });
-        widthSizeContainer.getChildren().addAll(lblWidthSize, widthSizeTextField);
+        widthSizeContainer.setSpacing(5);
+        Label lblWidthSize = new Label("Width :");
+        
+        Slider widthSlider = new Slider();
+        widthSlider.setMin(0);
+        widthSlider.setMax(255);
+        widthSlider.setValue(45);
+        // enable TickLabels and Tick Marks
+        widthSlider.setShowTickLabels(true);
+        widthSlider.setShowTickMarks(true);
+        widthSlider.setBlockIncrement(10);
+        // Adding Listener to value property.
+        widthSlider.valueProperty().addListener(new ChangeListener<Number>() {
+
+			@Override
+			public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
+				// TODO Auto-generated method stub
+				lblWidthSize.setText(String.format("Width : %.2f units", newValue.doubleValue()));
+				operator.setWidthSize(newValue.doubleValue());
+			}
+        	
+		});
+        widthSizeContainer.getChildren().addAll(lblWidthSize, widthSlider);
 
         //Size - height.
         VBox heightSizeContainer = new VBox();
         heightSizeContainer.setPrefWidth(205.0);
-        heightSizeContainer.setSpacing(10);
-        Label lblHeightSize = new Label("Size height");
-        TextField heightSizeTextField = new TextField(String.valueOf(45.0));
-        heightSizeTextField.setPrefSize(205.0, 27.0);
-        //Listener to capture text change.
-        heightSizeTextField.textProperty().addListener((observable, oldValue, newValue) -> {
-            operator.setHeightSize(Double.parseDouble(newValue));
-        });
-        heightSizeContainer.getChildren().addAll(lblHeightSize, heightSizeTextField);
+        heightSizeContainer.setSpacing(5);
+        Label lblHeightSize = new Label("Height :");
+        
+        Slider heightSlider = new Slider();
+        heightSlider.setMin(0);
+        heightSlider.setMax(255);
+        heightSlider.setValue(45);
+        // enable TickLabels and Tick Marks
+        heightSlider.setShowTickLabels(true);
+        heightSlider.setShowTickMarks(true);
+        heightSlider.setBlockIncrement(10);
+        // Adding Listener to value property.
+        heightSlider.valueProperty().addListener(new ChangeListener<Number>() {
+
+			@Override
+			public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
+				// TODO Auto-generated method stub
+				lblHeightSize.setText(String.format("Height : %.2f units", newValue.doubleValue()));
+				operator.setHeightSize(newValue.doubleValue());
+			}
+        	
+		});
+        heightSizeContainer.getChildren().addAll(lblHeightSize, heightSlider);
 
         //Point - x.
         VBox xPointContainer = new VBox();
         xPointContainer.setPrefWidth(205.0);
         xPointContainer.setSpacing(10);
         Label lblXPoint = new Label("Point: X");
-        TextField xPointTextField = new TextField(String.valueOf(-1));
-        xPointTextField.setPrefSize(205.0, 27.0);
-        //Listener to capture text change.
-        xPointTextField.textProperty().addListener((observable, oldValue, newValue) -> {
-            operator.setPointX(Double.parseDouble(newValue));
-        });
-        xPointContainer.getChildren().addAll(lblXPoint, xPointTextField);
+        Label lblxPointDisplay = new Label(" ");
+        
+        // set the color of the text
+        lblxPointDisplay.setTextFill(Color.BLACK);
+        Slider xPointSlider = new Slider();
+        xPointSlider.setMin(-10);
+        xPointSlider.setMax(10);
+        xPointSlider.setValue(-1);
+        // enable TickLabels and Tick Marks
+        xPointSlider.setShowTickLabels(true);
+        xPointSlider.setShowTickMarks(true);
+        xPointSlider.setBlockIncrement(10);
+        // Adding Listener to value property.
+        xPointSlider.valueProperty().addListener(new ChangeListener<Number>() {
+
+			@Override
+			public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
+				// TODO Auto-generated method stub
+				lblxPointDisplay.setText(String.format("%.2f units", newValue.doubleValue()));
+				operator.setPointX(newValue.doubleValue());
+			}
+        	
+		});
+        xPointContainer.getChildren().addAll(lblXPoint, lblxPointDisplay, xPointSlider);
 
         //Point - y.
         VBox yPointContainer = new VBox();
         yPointContainer.setPrefWidth(205.0);
         yPointContainer.setSpacing(10);
         Label lblYPoint = new Label("Point: Y");
-        TextField yPointTextField = new TextField(String.valueOf(-1));
-        yPointTextField.setPrefSize(205.0, 27.0);
-        //Listener to capture text change.
-        yPointTextField.textProperty().addListener((observable, oldValue, newValue) -> {
-            operator.setPointY(Double.parseDouble(newValue));
-        });
-        yPointContainer.getChildren().addAll(lblYPoint, yPointTextField);
+        Label lblYPointDisplay = new Label(" ");
+        
+        // set the color of the text
+        lblYPointDisplay.setTextFill(Color.BLACK);
+        Slider yPointSlider = new Slider();
+        yPointSlider.setMin(-10);
+        yPointSlider.setMax(10);
+        yPointSlider.setValue(-1);
+        // enable TickLabels and Tick Marks
+        yPointSlider.setShowTickLabels(true);
+        yPointSlider.setShowTickMarks(true);
+        yPointSlider.setBlockIncrement(10);
+        // Adding Listener to value property.
+        yPointSlider.valueProperty().addListener(new ChangeListener<Number>() {
+
+			@Override
+			public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
+				// TODO Auto-generated method stub
+				lblYPointDisplay.setText(String.format("%.2f units", newValue.doubleValue()));
+				operator.setPointY(newValue.doubleValue());
+			}
+        	
+		});
+        yPointContainer.getChildren().addAll(lblYPoint, lblYPointDisplay, yPointSlider);
 
         //Space container
         VBox spaceContainer = new VBox();
@@ -100,7 +180,7 @@ public class BoxFilterPropertiesForm extends AbstractPropertiesForm {
         boxFilterPropertiesContainer.setLayoutY(14);
         boxFilterPropertiesContainer.getChildren().addAll(
                 boxFilterTitleContainer,
-                depthSizeContainer,
+                depthSliderContainer,
                 widthSizeContainer,
                 heightSizeContainer,
                 xPointContainer,

--- a/src/main/java/com/imagelab/view/forms/BoxFilterPropertiesForm.java
+++ b/src/main/java/com/imagelab/view/forms/BoxFilterPropertiesForm.java
@@ -6,6 +6,7 @@ import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.scene.control.Label;
 import javafx.scene.control.Slider;
+import javafx.scene.control.TextField;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 
@@ -29,7 +30,9 @@ public class BoxFilterPropertiesForm extends AbstractPropertiesForm {
         depthSliderContainer.setPrefWidth(205.0);
         depthSliderContainer.setSpacing(10);
         Label lblDepthSlider = new Label("Depth :");
-     
+        TextField boxdepthTextField = new TextField(String.valueOf(1));
+        boxdepthTextField.setPrefSize(205.0, 27.0);
+        
         Slider depthSlider = new Slider();
         depthSlider.setMin(0);
         depthSlider.setMax(100);
@@ -47,9 +50,14 @@ public class BoxFilterPropertiesForm extends AbstractPropertiesForm {
 				lblDepthSlider.setText(String.format("Depth : %d units", (int)newValue.doubleValue()));
 				operator.setDepth((int)newValue.doubleValue());
 			}
-        	
+			
 		});
-        depthSliderContainer.getChildren().addAll(lblDepthSlider, depthSlider);
+        boxdepthTextField.textProperty().addListener((observable, oldValue, newValue) -> {
+        	depthSlider.setValue(Integer.parseInt(newValue));
+            operator.setDepth(Integer.parseInt(newValue));
+        });
+        
+        depthSliderContainer.getChildren().addAll(lblDepthSlider, depthSlider, boxdepthTextField);
 
         //Size - width.
         VBox widthSizeContainer = new VBox();
@@ -108,12 +116,11 @@ public class BoxFilterPropertiesForm extends AbstractPropertiesForm {
         //Point - x.
         VBox xPointContainer = new VBox();
         xPointContainer.setPrefWidth(205.0);
-        xPointContainer.setSpacing(10);
         Label lblXPoint = new Label("Point: X");
-        Label lblxPointDisplay = new Label(" ");
+        TextField xPointTextField = new TextField(String.valueOf(1));
+        xPointTextField.setPrefSize(205.0, 27.0);
         
         // set the color of the text
-        lblxPointDisplay.setTextFill(Color.BLACK);
         Slider xPointSlider = new Slider();
         xPointSlider.setMin(-10);
         xPointSlider.setMax(10);
@@ -128,22 +135,26 @@ public class BoxFilterPropertiesForm extends AbstractPropertiesForm {
 			@Override
 			public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
 				// TODO Auto-generated method stub
-				lblxPointDisplay.setText(String.format("%.2f units", newValue.doubleValue()));
+				lblXPoint.setText(String.format("Point: X : %.2f units", newValue.doubleValue()));
+				xPointTextField.setText(newValue.toString());
 				operator.setPointX(newValue.doubleValue());
 			}
         	
 		});
-        xPointContainer.getChildren().addAll(lblXPoint, lblxPointDisplay, xPointSlider);
+        xPointTextField.textProperty().addListener((observable, oldValue, newValue) -> {
+        	xPointSlider.setValue(Double.parseDouble(newValue));
+            operator.setPointX(Double.parseDouble(newValue));
+        });
+        xPointContainer.getChildren().addAll(lblXPoint, xPointSlider, xPointTextField);
 
         //Point - y.
         VBox yPointContainer = new VBox();
         yPointContainer.setPrefWidth(205.0);
-        yPointContainer.setSpacing(10);
         Label lblYPoint = new Label("Point: Y");
-        Label lblYPointDisplay = new Label(" ");
+        TextField yPointTextField = new TextField(String.valueOf(1));
+        yPointTextField.setPrefSize(205.0, 27.0);
         
         // set the color of the text
-        lblYPointDisplay.setTextFill(Color.BLACK);
         Slider yPointSlider = new Slider();
         yPointSlider.setMin(-10);
         yPointSlider.setMax(10);
@@ -158,12 +169,17 @@ public class BoxFilterPropertiesForm extends AbstractPropertiesForm {
 			@Override
 			public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
 				// TODO Auto-generated method stub
-				lblYPointDisplay.setText(String.format("%.2f units", newValue.doubleValue()));
+				lblYPoint.setText(String.format("Point: Y : %.2f units", newValue.doubleValue()));
+				yPointTextField.setText(newValue.toString());
 				operator.setPointY(newValue.doubleValue());
 			}
         	
 		});
-        yPointContainer.getChildren().addAll(lblYPoint, lblYPointDisplay, yPointSlider);
+        yPointTextField.textProperty().addListener((observable, oldValue, newValue) -> {
+        	yPointSlider.setValue(Double.parseDouble(newValue));
+        	operator.setPointY(Double.parseDouble(newValue));
+        });
+        yPointContainer.getChildren().addAll(lblYPoint, yPointSlider, yPointTextField);
 
         //Space container
         VBox spaceContainer = new VBox();


### PR DESCRIPTION
# Description

Add Sliders instead of Text Fields for the box filter operator in order to improve the UX features and to remove the empty field exception
![box-filter-slider-version](https://user-images.githubusercontent.com/52147094/114734318-bc365d00-9d61-11eb-9776-cca0bbbc9091.gif)

## Type of change

- Add Slider from javafx.scene
- Remove the text fields
Solves #63 