### PR TITLE
Add: SQRBoxFilter + Filter2D to filtering operators + apply validation and rules + styles + dashboard sync

### DIFF
--- a/src/main/java/com/imagelab/DashboardController.java
+++ b/src/main/java/com/imagelab/DashboardController.java
@@ -479,6 +479,7 @@ public class DashboardController implements Initializable {
                 FilterOperatorController.imageDilationEffectElement().element,
                 FilterOperatorController.erosionFilterEffectElement().element,
                 FilterOperatorController.bilateralFilterEffectElement().element,
+                FilterOperatorController.filter2DOperatorEffectElement().element,
                 FilterOperatorController.pyramidsUpFilterEffectElement().element,
                 FilterOperatorController.pyramidsDownFilterEffectElement().element,
                 FilterOperatorController.morphologicalOperatorEffectElement().element

--- a/src/main/java/com/imagelab/DashboardController.java
+++ b/src/main/java/com/imagelab/DashboardController.java
@@ -480,6 +480,7 @@ public class DashboardController implements Initializable {
                 FilterOperatorController.erosionFilterEffectElement().element,
                 FilterOperatorController.bilateralFilterEffectElement().element,
                 FilterOperatorController.filter2DOperatorEffectElement().element,
+                FilterOperatorController.sqrBoxFilterEffectElement().element,
                 FilterOperatorController.pyramidsUpFilterEffectElement().element,
                 FilterOperatorController.pyramidsDownFilterEffectElement().element,
                 FilterOperatorController.morphologicalOperatorEffectElement().element

--- a/src/main/java/com/imagelab/controllers/FilterOperatorController.java
+++ b/src/main/java/com/imagelab/controllers/FilterOperatorController.java
@@ -9,6 +9,7 @@ import com.imagelab.operator.filtering.ApplyFilter2D;
 import com.imagelab.operator.filtering.ApplyImagePyramid;
 import com.imagelab.operator.filtering.ApplyImagePyramidDown;
 import com.imagelab.operator.filtering.ApplyMorphological;
+import com.imagelab.operator.filtering.ApplySQRBoxFilter;
 import com.imagelab.view.AbstractInformationUI;
 import com.imagelab.view.InformationContainerView;
 import com.imagelab.view.forms.AbstractPropertiesForm;
@@ -20,6 +21,7 @@ import com.imagelab.view.forms.Filter2DPropertiesForm;
 import com.imagelab.view.forms.MorphologicalPropertiesForm;
 import com.imagelab.view.forms.PyramidDownFilterPropertiesForm;
 import com.imagelab.view.forms.PyramidUpFilterPropertiesForm;
+import com.imagelab.view.forms.SQRBoxFilterPropertiesForm;
 
 public class FilterOperatorController {
 	public static OperatorUIElement boxFilerEffectElement() {
@@ -187,6 +189,26 @@ public class FilterOperatorController {
         filter2DOperator.elementStyleId = "applyFilter2D";
         filter2DOperator.buildElement();
         return filter2DOperator;
+    }
+    public static OperatorUIElement sqrBoxFilterEffectElement() {
+    	//apply SQRBoxFilter UI element
+    	OperatorUIElement sqrBoxOperator = new OperatorUIElement() {
+    		@Override
+        	public AbstractInformationUI buildInformationUI() {
+        		return new InformationContainerView(ApplySQRBoxFilter
+                        .Information.OPERATOR_INFO.toString());
+        	}
+        	@Override
+            public AbstractPropertiesForm buildPropertiesFormUI() {
+                return new SQRBoxFilterPropertiesForm((ApplySQRBoxFilter) this.operator);
+            }
+    	};
+    	sqrBoxOperator.operator = new ApplySQRBoxFilter();
+    	sqrBoxOperator.operatorId = ApplySQRBoxFilter.class.getCanonicalName();
+    	sqrBoxOperator.operatorName = "SQR-BOX-FILTER";
+    	sqrBoxOperator.elementStyleId = "applySQRBox";
+    	sqrBoxOperator.buildElement();
+        return sqrBoxOperator;
     }
 
 }

--- a/src/main/java/com/imagelab/controllers/FilterOperatorController.java
+++ b/src/main/java/com/imagelab/controllers/FilterOperatorController.java
@@ -5,6 +5,7 @@ import com.imagelab.operator.filtering.ApplyBilateralFilter;
 import com.imagelab.operator.filtering.ApplyBoxFilter;
 import com.imagelab.operator.filtering.ApplyDilation;
 import com.imagelab.operator.filtering.ApplyErosion;
+import com.imagelab.operator.filtering.ApplyFilter2D;
 import com.imagelab.operator.filtering.ApplyImagePyramid;
 import com.imagelab.operator.filtering.ApplyImagePyramidDown;
 import com.imagelab.operator.filtering.ApplyMorphological;
@@ -15,6 +16,7 @@ import com.imagelab.view.forms.BilateralFilterPropertiesForm;
 import com.imagelab.view.forms.BoxFilterPropertiesForm;
 import com.imagelab.view.forms.DilationFilterPropertiesForm;
 import com.imagelab.view.forms.ErosionFilterPropertiesForm;
+import com.imagelab.view.forms.Filter2DPropertiesForm;
 import com.imagelab.view.forms.MorphologicalPropertiesForm;
 import com.imagelab.view.forms.PyramidDownFilterPropertiesForm;
 import com.imagelab.view.forms.PyramidUpFilterPropertiesForm;
@@ -165,6 +167,26 @@ public class FilterOperatorController {
         morphologicalOperator.elementStyleId = "applyMorphological";
         morphologicalOperator.buildElement();
         return morphologicalOperator;
+    }
+    public static OperatorUIElement filter2DOperatorEffectElement() {
+    	//applyFilter2D Filter UI element
+        OperatorUIElement filter2DOperator = new OperatorUIElement() {
+        	@Override
+        	public AbstractInformationUI buildInformationUI() {
+        		return new InformationContainerView(ApplyFilter2D
+                        .Information.OPERATOR_INFO.toString());
+        	}
+        	@Override
+            public AbstractPropertiesForm buildPropertiesFormUI() {
+                return new Filter2DPropertiesForm((ApplyFilter2D) this.operator);
+            }
+        };
+        filter2DOperator.operator = new ApplyFilter2D();
+        filter2DOperator.operatorId = ApplyFilter2D.class.getCanonicalName();
+        filter2DOperator.operatorName = "FILTER2D";
+        filter2DOperator.elementStyleId = "applyFilter2D";
+        filter2DOperator.buildElement();
+        return filter2DOperator;
     }
 
 }

--- a/src/main/java/com/imagelab/operator/filtering/ApplyFilter2D.java
+++ b/src/main/java/com/imagelab/operator/filtering/ApplyFilter2D.java
@@ -1,0 +1,131 @@
+package com.imagelab.operator.filtering;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Point;
+import org.opencv.core.Size;
+import org.opencv.imgproc.Imgproc;
+
+import com.imagelab.operator.OpenCVOperator;
+import com.imagelab.operator.basic.ReadImage;
+import com.imagelab.operator.basic.WriteImage;
+import com.imagelab.operator.geotransformation.RotateImage;
+import com.imagelab.operator.geotransformation.ScaleImage;
+import com.imagelab.operator.imagebluring.ApplyBlurEffect;
+import com.imagelab.operator.imagebluring.ApplyGaussianBlurEffect;
+import com.imagelab.operator.imagebluring.ApplyMedianBlurEffect;
+import com.imagelab.operator.imageconversion.ColoredImageToBinary;
+import com.imagelab.operator.imageconversion.ConvertToGrayscale;
+
+public class ApplyFilter2D extends OpenCVOperator {
+	/**
+     * To get the depth of the output image.
+     *
+     * @return - output depth.
+     */
+	private int ddepth = -1;
+	
+	/**
+     * This method contains the logic which validates the applicable
+     * openCV operations for a particular openCV operator.
+     *
+     * @param previous - accepts the previous operator to validate.
+     * @return - whether the received operator is valid or not.
+     */
+	@Override
+	public boolean validate(OpenCVOperator previous) {
+		if (previous == null) {
+            return false;
+        }
+        return allowedOperators().contains(previous.getClass());
+	}
+	/**
+     * This method contains the openCV operator related specific logic.
+     *
+     * @param image - accepts the mat object processed from the previous steps.
+     * @return - processed computed Mat obj.
+     */
+	@Override
+	public Mat compute(Mat image) {
+		// call to the private function
+		return applyFilter2D(image, getDepth());
+	}
+	/**
+     * This method contains the applicable openCV operator for the selected
+     * openCV operator.
+     *
+     * @return - applicable operator.
+     */
+	@Override
+	public Set<Class<?>> allowedOperators() {
+		Set<Class<?>> allowed = new HashSet<>();
+        allowed.add(ReadImage.class);
+        allowed.add(RotateImage.class);
+        allowed.add(WriteImage.class);
+        allowed.add(ScaleImage.class);
+        allowed.add(ColoredImageToBinary.class);
+        allowed.add(ConvertToGrayscale.class);
+        allowed.add(ApplyBlurEffect.class);
+        allowed.add(ApplyGaussianBlurEffect.class);
+        allowed.add(ApplyMedianBlurEffect.class);
+        allowed.add(ApplyBoxFilter.class);
+        allowed.add(ApplyImagePyramidDown.class);
+        allowed.add(ApplyImagePyramid.class);
+        //allowed.add(ApplyDilation.class);
+        allowed.add(ApplyErosion.class);
+        return allowed;
+	}
+	private Mat applyFilter2D(Mat src, int ddepth) {
+		 // Creating an empty matrix to store the result
+	      Mat image = new Mat();
+	      
+	      // creating kernel matrix
+	      Mat kernel = Mat.ones(2,2, CvType.CV_32F);
+	      
+	      //construct the kernel
+	      for(int i = 0; i<kernel.rows(); i++) {
+	          for(int j = 0; j<kernel.cols(); j++) {
+	             double[] m = kernel.get(i, j);
+
+	             for(int k = 1; k<m.length; k++) {
+	                m[k] = m[k]/(2 * 2);
+	             }
+	             kernel.put(i,j, m);
+	          }
+	       }
+	      //Apply the filter to convoluate
+	      Imgproc.filter2D(src, image, ddepth, kernel);
+	      
+	      return image;
+		
+	}
+	/**
+     * To get the ddepth of the output image.
+     *
+     * @return - output depth.
+     */
+	public int getDepth() {
+		return ddepth;
+	}
+	/**
+     * To set the filter depth of the output image.
+     *
+     * @return - output depth.
+     */ 
+	public void setDepth(int depth) {
+		this.ddepth = depth;
+	}
+		
+	public enum Information{
+		OPERATOR_INFO{
+			public String toString() {
+				return "Filter2D\n\n This Filter operation"
+						+" convolves an image with the kernel. ddepth respresent the depth of output image."
+						+" You can perfrom this operation on an image using the Filter2D() method of imgproc class.";
+			}
+		}
+	}
+}

--- a/src/main/java/com/imagelab/operator/filtering/ApplySQRBoxFilter.java
+++ b/src/main/java/com/imagelab/operator/filtering/ApplySQRBoxFilter.java
@@ -1,0 +1,157 @@
+package com.imagelab.operator.filtering;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Size;
+import org.opencv.imgproc.Imgproc;
+
+import com.imagelab.operator.OpenCVOperator;
+import com.imagelab.operator.basic.ReadImage;
+import com.imagelab.operator.basic.WriteImage;
+import com.imagelab.operator.geotransformation.RotateImage;
+import com.imagelab.operator.geotransformation.ScaleImage;
+import com.imagelab.operator.imagebluring.ApplyBlurEffect;
+import com.imagelab.operator.imagebluring.ApplyGaussianBlurEffect;
+import com.imagelab.operator.imagebluring.ApplyMedianBlurEffect;
+import com.imagelab.operator.imageconversion.ColoredImageToBinary;
+import com.imagelab.operator.imageconversion.ConvertToGrayscale;
+
+public class ApplySQRBoxFilter extends OpenCVOperator{
+
+	/**
+     * To get the depth of the output image.
+     *
+     * @return - output depth.
+     */
+	private int ddepth = -1;
+	
+	/**
+	 * To get the ksize x
+	 */
+	private int ksizex = 1;
+	/**
+	 * To get the ksize y
+	 */
+	private int ksizey = 1;
+	
+	
+	/**
+     * This method contains the logic which validates the applicable
+     * openCV operations for a particular openCV operator.
+     *
+     * @param previous - accepts the previous operator to validate.
+     * @return - whether the received operator is valid or not.
+     */
+	@Override
+	public boolean validate(OpenCVOperator previous) {
+		if (previous == null) {
+            return false;
+        }
+        return allowedOperators().contains(previous.getClass());
+	}
+	/**
+     * This method contains the openCV operator related specific logic.
+     *
+     * @param image - accepts the mat object processed from the previous steps.
+     * @return - processed computed Mat obj.
+     */
+	@Override
+	public Mat compute(Mat image) {
+		// call to the private function
+		
+		return applySQRBox(image, getDepth(),getX(),getY());
+	}
+	/**
+     * This method contains the applicable openCV operator for the selected
+     * openCV operator.
+     *
+     * @return - applicable operator.
+     */
+	@Override
+	public Set<Class<?>> allowedOperators() {
+		Set<Class<?>> allowed = new HashSet<>();
+        allowed.add(ReadImage.class);
+        allowed.add(RotateImage.class);
+        allowed.add(WriteImage.class);
+        allowed.add(ScaleImage.class);
+        allowed.add(ColoredImageToBinary.class);
+        allowed.add(ConvertToGrayscale.class);
+        allowed.add(ApplyBlurEffect.class);
+        allowed.add(ApplyGaussianBlurEffect.class);
+        allowed.add(ApplyMedianBlurEffect.class);
+        allowed.add(ApplyBoxFilter.class);
+        allowed.add(ApplyImagePyramidDown.class);
+        allowed.add(ApplyImagePyramid.class);
+        //allowed.add(ApplyDilation.class);
+        allowed.add(ApplyErosion.class);
+        return allowed;
+	}
+	private Mat applySQRBox(Mat src, int ddepth,int x,int y) {
+		  // Creating an empty matrix to store the result
+	      Mat image = new Mat();
+	      
+	      //Apply the filter
+	      Imgproc.sqrBoxFilter(src, image, ddepth, new Size(x,y));
+	      
+	      return image;
+		
+	}
+	/**
+     * To get the ddepth of the output image.
+     *
+     * @return - output depth.
+     */
+	public int getDepth() {
+		return ddepth;
+	}
+	/**
+     * To set the filter depth of the output image.
+     *
+     * @return - output depth.
+     */ 
+	public void setDepth(int depth) {
+		this.ddepth = depth;
+	}
+	/**
+	 * 
+	 * @return ksizex
+	 */
+	public int getX() {
+		return ksizex;
+	}
+	/**
+	 * Set the ksizex
+	 * @param x
+	 */
+	public void setX(int x) {
+		this.ksizex = x;
+	}
+	/**
+	 * 
+	 * @return ksizey
+	 */
+	public int getY() {
+		return ksizey;
+	}
+	/**
+	 * set the value ksizey
+	 * @param y
+	 */
+	public void setY(int y) {
+		this.ksizey = y;
+	}
+		
+	public enum Information{
+		OPERATOR_INFO{
+			public String toString() {
+				return "Filter2D\n\n This Filter operation"
+						+" convolves an image with the kernel. ddepth respresent the depth of output image."
+						+" You can perfrom this operation on an image using the Filter2D() method of imgproc class.";
+			}
+		}
+	}
+
+}

--- a/src/main/java/com/imagelab/operator/geotransformation/ScaleImage.java
+++ b/src/main/java/com/imagelab/operator/geotransformation/ScaleImage.java
@@ -14,6 +14,7 @@ import com.imagelab.operator.drawing.DrawCircle;
 import com.imagelab.operator.drawing.DrawLine;
 import com.imagelab.operator.filtering.ApplyBoxFilter;
 import com.imagelab.operator.filtering.ApplyErosion;
+import com.imagelab.operator.filtering.ApplyFilter2D;
 import com.imagelab.operator.filtering.ApplyImagePyramid;
 import com.imagelab.operator.filtering.ApplyImagePyramidDown;
 import com.imagelab.operator.imagebluring.ApplyBlurEffect;
@@ -73,6 +74,7 @@ public class ScaleImage extends OpenCVOperator{
         allowed.add(ApplyImagePyramidDown.class);
         allowed.add(ApplyImagePyramid.class);
         allowed.add(ApplyErosion.class);
+        allowed.add(ApplyFilter2D.class);
         allowed.add(DrawCircle.class);
         allowed.add(DrawLine.class);
         return allowed;

--- a/src/main/java/com/imagelab/operator/geotransformation/ScaleImage.java
+++ b/src/main/java/com/imagelab/operator/geotransformation/ScaleImage.java
@@ -17,6 +17,7 @@ import com.imagelab.operator.filtering.ApplyErosion;
 import com.imagelab.operator.filtering.ApplyFilter2D;
 import com.imagelab.operator.filtering.ApplyImagePyramid;
 import com.imagelab.operator.filtering.ApplyImagePyramidDown;
+import com.imagelab.operator.filtering.ApplySQRBoxFilter;
 import com.imagelab.operator.imagebluring.ApplyBlurEffect;
 import com.imagelab.operator.imagebluring.ApplyGaussianBlurEffect;
 import com.imagelab.operator.imagebluring.ApplyMedianBlurEffect;
@@ -75,6 +76,7 @@ public class ScaleImage extends OpenCVOperator{
         allowed.add(ApplyImagePyramid.class);
         allowed.add(ApplyErosion.class);
         allowed.add(ApplyFilter2D.class);
+        allowed.add(ApplySQRBoxFilter.class);
         allowed.add(DrawCircle.class);
         allowed.add(DrawLine.class);
         return allowed;

--- a/src/main/java/com/imagelab/view/forms/Filter2DPropertiesForm.java
+++ b/src/main/java/com/imagelab/view/forms/Filter2DPropertiesForm.java
@@ -1,0 +1,49 @@
+package com.imagelab.view.forms;
+
+import com.imagelab.operator.filtering.ApplyFilter2D;
+
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.VBox;
+
+public class Filter2DPropertiesForm extends AbstractPropertiesForm {
+	public Filter2DPropertiesForm(ApplyFilter2D operator) {
+		//Filter2D title container.
+        PropertiesFormTitleContainer filter2DTitleContainer;
+        filter2DTitleContainer = new PropertiesFormTitleContainer("Filter 2D Properties");
+        
+        //Depth
+        VBox depthContainer = new VBox();
+        depthContainer.setPrefWidth(205.0);
+        depthContainer.setSpacing(10);
+        Label lblDepth = new Label("Depth : ");
+        TextField depthTextField = new TextField(String.valueOf(1));
+        depthTextField.setPrefSize(205.0, 27.0);
+        //Listener to capture text change.
+        depthTextField.textProperty().addListener((observable, oldValue, newValue) -> {
+            operator.setDepth(Integer.parseInt(newValue));
+        });
+        depthContainer.getChildren().addAll(lblDepth, depthTextField);
+        
+        //Space container
+        VBox spaceContainer = new VBox();
+        spaceContainer.setPrefWidth(205.0);
+        spaceContainer.setSpacing(10);
+        Label lblSpaceOne = new Label("");
+        Label lblSpaceTwo = new Label("");
+        spaceContainer.getChildren().addAll(lblSpaceOne, lblSpaceTwo);
+        
+        VBox filter2DPropertiesContainer = new VBox();
+        filter2DPropertiesContainer.setPrefSize(205, 47);
+        filter2DPropertiesContainer.setSpacing(20);
+        filter2DPropertiesContainer.setLayoutX(14);
+        filter2DPropertiesContainer.setLayoutY(14);
+        filter2DPropertiesContainer.getChildren().addAll(
+        		filter2DTitleContainer,
+        		depthContainer,
+        		spaceContainer
+               
+        );
+        getChildren().addAll(filter2DPropertiesContainer);
+	}
+}

--- a/src/main/java/com/imagelab/view/forms/SQRBoxFilterPropertiesForm.java
+++ b/src/main/java/com/imagelab/view/forms/SQRBoxFilterPropertiesForm.java
@@ -1,0 +1,77 @@
+package com.imagelab.view.forms;
+
+import com.imagelab.operator.filtering.ApplySQRBoxFilter;
+
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.VBox;
+
+public class SQRBoxFilterPropertiesForm extends AbstractPropertiesForm{
+  public SQRBoxFilterPropertiesForm(ApplySQRBoxFilter operator) {
+	  //SQRBox title container.
+      PropertiesFormTitleContainer sqrBoxFilterTitleContainer;
+      sqrBoxFilterTitleContainer = new PropertiesFormTitleContainer("SQRBox Filter Properties");
+      
+      //Depth
+      VBox depthContainer = new VBox();
+      depthContainer.setPrefWidth(205.0);
+      depthContainer.setSpacing(10);
+      Label lblDepth = new Label("Depth : ");
+      TextField depthTextField = new TextField(String.valueOf(1));
+      depthTextField.setPrefSize(205.0, 27.0);
+      //Listener to capture text change.
+      depthTextField.textProperty().addListener((observable, oldValue, newValue) -> {
+          operator.setDepth(Integer.parseInt(newValue));
+      });
+      depthContainer.getChildren().addAll(lblDepth, depthTextField);
+      
+      //Size - X
+      VBox xContainer = new VBox();
+      xContainer.setPrefWidth(205.0);
+      xContainer.setSpacing(10);
+      Label lblSizeX = new Label("Size - X : ");
+      TextField xTextField = new TextField(String.valueOf(1));
+      xTextField.setPrefSize(205.0, 27.0);
+      //Listener to capture text change.
+      xTextField.textProperty().addListener((observable, oldValue, newValue) -> {
+          operator.setX(Integer.parseInt(newValue));
+      });
+      xContainer.getChildren().addAll(lblSizeX, xTextField);
+      
+      //Size - Y
+      VBox yContainer = new VBox();
+      yContainer.setPrefWidth(205.0);
+      yContainer.setSpacing(10);
+      Label lblSizeY = new Label("Size - Y : ");
+      TextField yTextField = new TextField(String.valueOf(1));
+      yTextField.setPrefSize(205.0, 27.0);
+      //Listener to capture text change.
+      yTextField.textProperty().addListener((observable, oldValue, newValue) -> {
+          operator.setY(Integer.parseInt(newValue));
+      });
+      yContainer.getChildren().addAll(lblSizeY, yTextField);
+      
+      //Space container
+      VBox spaceContainer = new VBox();
+      spaceContainer.setPrefWidth(205.0);
+      spaceContainer.setSpacing(10);
+      Label lblSpaceOne = new Label("");
+      Label lblSpaceTwo = new Label("");
+      spaceContainer.getChildren().addAll(lblSpaceOne, lblSpaceTwo);
+      
+      VBox srqBoxFilterPropertiesContainer = new VBox();
+      srqBoxFilterPropertiesContainer.setPrefSize(205, 47);
+      srqBoxFilterPropertiesContainer.setSpacing(20);
+      srqBoxFilterPropertiesContainer.setLayoutX(14);
+      srqBoxFilterPropertiesContainer.setLayoutY(14);
+      srqBoxFilterPropertiesContainer.getChildren().addAll(
+      		sqrBoxFilterTitleContainer,
+      		depthContainer,
+      		xContainer,
+      		yContainer,
+      		spaceContainer
+             
+      );
+      getChildren().addAll(srqBoxFilterPropertiesContainer);
+  }
+}

--- a/src/main/resources/com/imagelab/style.css
+++ b/src/main/resources/com/imagelab/style.css
@@ -178,6 +178,12 @@
  	-fx-background-color: #5177c9;
  	-fx-text-fill: white;
  }
+ /**
+  * Apply SQRBox Filter styles */
+#applySQRBox{
+	-fx-background-color: #2e4b89;
+ 	-fx-text-fill: white;
+}  
 /**Apply Morphological Operator styles
  *  */
  #applyMorphological{

--- a/src/main/resources/com/imagelab/style.css
+++ b/src/main/resources/com/imagelab/style.css
@@ -172,6 +172,12 @@
 	-fx-background-color: #3268b1;
  	-fx-text-fill: white;
 }
+/**
+ * Apply Filter2D styles */
+ #applyFilter2D{
+ 	-fx-background-color: #5177c9;
+ 	-fx-text-fill: white;
+ }
 /**Apply Morphological Operator styles
  *  */
  #applyMorphological{


### PR DESCRIPTION
# Description

This PR consists of two filter operators including filter2D for convolution purposes and sqrboxfilter for apply brightness for the images. Both operators included into the dashboard with proper validation and rules. operator styles are also applied.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Operators have been properly tested using sample images.(vector image + RGB image)

https://user-images.githubusercontent.com/52147094/126902100-2a7ef221-7ee4-4a43-8cc5-5226d7ab16b3.mp4

