### PR TITLE
Add: Image Moments + Convex Hull for Contouring Operations + Apply Properties + Dashboard Sync + Validations + Operator Styles

### DIFF
--- a/src/main/java/com/imagelab/DashboardController.java
+++ b/src/main/java/com/imagelab/DashboardController.java
@@ -536,7 +536,9 @@ public class DashboardController implements Initializable {
         contourOperationContainer.getChildren().addAll(
         	   // Populating contourOperationsContainer
         	   ImageContoursController.findContoursElement().element,
-        	   ImageContoursController.boundingBoxesForContoursElement().element
+        	   ImageContoursController.boundingBoxesForContoursElement().element,
+        	   ImageContoursController.imageMomentsElement().element,
+        	   ImageContoursController.convexHullElement().element
         );
         histogramOperationContainer.setSpacing(15d);
         histogramOperationContainer.setAlignment(Pos.TOP_CENTER);

--- a/src/main/java/com/imagelab/controllers/ImageContoursController.java
+++ b/src/main/java/com/imagelab/controllers/ImageContoursController.java
@@ -3,13 +3,17 @@ package com.imagelab.controllers;
 import com.imagelab.component.OperatorUIElement;
 import com.imagelab.operator.histogram.HistogramCalculation;
 import com.imagelab.operator.imagecontours.BoundingBoxesForContours;
+import com.imagelab.operator.imagecontours.ConvexHull;
 import com.imagelab.operator.imagecontours.FindContours;
+import com.imagelab.operator.imagecontours.ImageMoments;
 import com.imagelab.view.AbstractInformationUI;
 import com.imagelab.view.InformationContainerView;
 import com.imagelab.view.forms.AbstractPropertiesForm;
 import com.imagelab.view.forms.BoundingBoxesForContoursPropertiesForm;
+import com.imagelab.view.forms.ConvexHullPropertiesForm;
 import com.imagelab.view.forms.FindContoursPropertiesForm;
 import com.imagelab.view.forms.HistogramCalculationPropertiesForm;
+import com.imagelab.view.forms.ImageMomentsPropertiesForm;
 
 public class ImageContoursController {
 	public static OperatorUIElement findContoursElement() {
@@ -53,5 +57,47 @@ public class ImageContoursController {
         boundingBoxesForContours.elementStyleId = "boundBoxContours";
         boundingBoxesForContours.buildElement();
         return boundingBoxesForContours;
+	}
+	public static OperatorUIElement imageMomentsElement() {
+		//Image Moments For Contours properties form.
+        OperatorUIElement imageMoments = new OperatorUIElement() {
+            @Override
+            public AbstractInformationUI buildInformationUI() {
+                return new InformationContainerView(ImageMoments
+                        .Information.OPERATOR_INFO.toString());
+            }
+
+            @Override
+            public AbstractPropertiesForm buildPropertiesFormUI() {
+                return new ImageMomentsPropertiesForm((ImageMoments) this.operator);
+            }
+        };
+        imageMoments.operator = new ImageMoments();
+        imageMoments.operatorId = ImageMoments.class.getCanonicalName();
+        imageMoments.operatorName = "IMAGE-MOMENTS";
+        imageMoments.elementStyleId = "imageMoments";
+        imageMoments.buildElement();
+        return imageMoments;
+	}
+	public static OperatorUIElement convexHullElement() {
+		//Image Moments For Contours properties form.
+        OperatorUIElement convexHull = new OperatorUIElement() {
+            @Override
+            public AbstractInformationUI buildInformationUI() {
+                return new InformationContainerView(ConvexHull
+                        .Information.OPERATOR_INFO.toString());
+            }
+
+            @Override
+            public AbstractPropertiesForm buildPropertiesFormUI() {
+                return new ConvexHullPropertiesForm((ConvexHull) this.operator);
+            }
+        };
+        convexHull.operator = new ConvexHull();
+        convexHull.operatorId = ConvexHull.class.getCanonicalName();
+        convexHull.operatorName = "CONVEX-HULL";
+        convexHull.elementStyleId = "convexHull";
+        convexHull.buildElement();
+        return convexHull;
 	}
 }

--- a/src/main/java/com/imagelab/operator/imagecontours/ConvexHull.java
+++ b/src/main/java/com/imagelab/operator/imagecontours/ConvexHull.java
@@ -1,0 +1,118 @@
+package com.imagelab.operator.imagecontours;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.MatOfInt;
+import org.opencv.core.MatOfPoint;
+import org.opencv.core.MatOfPoint2f;
+import org.opencv.core.Point;
+import org.opencv.core.Scalar;
+import org.opencv.imgproc.Imgproc;
+import org.opencv.imgproc.Moments;
+
+import com.imagelab.operator.OpenCVOperator;
+import com.imagelab.operator.basic.ReadImage;
+import com.imagelab.operator.basic.WriteImage;
+
+public class ConvexHull extends OpenCVOperator{
+
+	/*
+	 * Contours
+	 */
+	private ArrayList<MatOfPoint> contours;
+	/*
+	 * Random value - colors
+	 */
+	private Random rng = new Random(12345);
+	@Override
+	public boolean validate(OpenCVOperator previous) {
+		// TODO Auto-generated method stub
+		if (previous == null || previous.getClass() != FindContours.class) {
+            return false;
+        }else if(previous.getClass() == FindContours.class) {
+			contours = FindContours.getContours();
+		}
+        return allowedOperators().contains(previous.getClass());
+	}
+
+	@Override
+	public Mat compute(Mat image) {
+		System.out.println("Applied the convex Hull");
+		return convexHull(image,getContoursList());
+	}
+
+	private Mat convexHull(Mat cannyOutput, ArrayList<MatOfPoint> contours) {
+		// Define the empty Matrix for convexHull
+		Mat drawing = Mat.zeros(cannyOutput.size(), CvType.CV_8UC3);
+		/**
+		 * Define the points for convex Hull using a ArrayList
+		 */
+		ArrayList<MatOfPoint> hullList = new ArrayList<>();
+        
+		/**
+		 * Save the points  from contours
+		 */
+		for (MatOfPoint contour : contours) {
+            MatOfInt hull = new MatOfInt();
+            /**
+             * Apply ConvexHull Operation for identify the boundaries
+             */
+            Imgproc.convexHull(contour, hull);
+            
+            Point[] contourArray = contour.toArray();
+            Point[] hullPoints = new Point[hull.rows()];
+            List<Integer> hullContourIdxList = hull.toList();
+            
+            for (int i = 0; i < hullContourIdxList.size(); i++) {
+                hullPoints[i] = contourArray[hullContourIdxList.get(i)];
+            }
+            hullList.add(new MatOfPoint(hullPoints));
+        }
+        
+        for (int i = 0; i < contours.size(); i++) {
+            Scalar color = new Scalar(rng.nextInt(256), rng.nextInt(256), rng.nextInt(256));
+            Imgproc.drawContours(drawing, contours, i, color);
+            Imgproc.drawContours(drawing, hullList, i, color );
+        }
+        
+		return drawing;
+	}
+
+	@Override
+	public Set<Class<?>> allowedOperators() {
+		Set<Class<?>> allowed = new HashSet<>();
+		allowed.add(ReadImage.class);
+        allowed.add(WriteImage.class);
+        allowed.add(FindContours.class);
+        return allowed;
+	}
+	
+	public ArrayList<MatOfPoint>  getContoursList() {
+		return this.contours;
+	}
+	
+	public enum Information {
+        /**
+         * Operator information in string format.
+         */
+        OPERATOR_INFO {
+            /**
+             * @return - Operator information and name
+             * of the operator.
+             */
+            public String toString() {
+                return "Convex Hull \n\n "
+                		+ "It is a binary image with set of pixels included in the smallest convex ploygon"
+                		+ " that surrounded all white pixels in the input. "
+                		+ "We can use convexHull() function OpenCV improve class in order to operate this action.";
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/imagelab/operator/imagecontours/ImageMoments.java
+++ b/src/main/java/com/imagelab/operator/imagecontours/ImageMoments.java
@@ -1,0 +1,115 @@
+package com.imagelab.operator.imagecontours;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.MatOfPoint;
+import org.opencv.core.MatOfPoint2f;
+import org.opencv.core.Point;
+import org.opencv.core.Scalar;
+import org.opencv.imgproc.Imgproc;
+import org.opencv.imgproc.Moments;
+
+import com.imagelab.operator.OpenCVOperator;
+import com.imagelab.operator.basic.ReadImage;
+import com.imagelab.operator.basic.WriteImage;
+
+public class ImageMoments extends OpenCVOperator {
+
+	/*
+	 * Contours
+	 */
+	private ArrayList<MatOfPoint> contours;
+	/*
+	 * Random value - colors
+	 */
+	private Random rng = new Random(12345);
+	
+	@Override
+	public boolean validate(OpenCVOperator previous) {
+		if (previous == null || previous.getClass() != FindContours.class) {
+            return false;
+        }else if(previous.getClass() == FindContours.class) {
+			contours = FindContours.getContours();
+		}
+        return allowedOperators().contains(previous.getClass());
+	}
+
+	@Override
+	public Mat compute(Mat image) {
+		return imageMoments(image,getContoursList());
+	}
+
+	private Mat imageMoments(Mat cannyOutput, ArrayList<MatOfPoint> contours) {
+		// TODO Auto-generated method stub
+		/**
+		 * Save all image Moments
+		 */
+		ArrayList<Moments> mu = new ArrayList<>(contours.size());
+        for (int i = 0; i < contours.size(); i++) {
+            mu.add(Imgproc.moments(contours.get(i)));
+        }
+        /**
+         * List of Contour Points
+         */
+        ArrayList<Point> mc = new ArrayList<>(contours.size());
+        for (int i = 0; i < contours.size(); i++) {
+            //add 1e-5 to avoid division by zero
+            mc.add(new Point(mu.get(i).m10 / (mu.get(i).m00 + 1e-5), mu.get(i).m01 / (mu.get(i).m00 + 1e-5)));
+        }
+        /**
+         * Assign CannyOutput for the drawing Mat Object
+         */
+        Mat drawing = Mat.zeros(cannyOutput.size(), CvType.CV_8UC3);
+        for (int i = 0; i < contours.size(); i++) {
+            Scalar color = new Scalar(rng.nextInt(256), rng.nextInt(256), rng.nextInt(256));
+            Imgproc.drawContours(drawing, contours, i, color, 2);
+            Imgproc.circle(drawing, mc.get(i), 4, color, -1);
+        }
+        
+        System.out.println("\t Info: Area and Contour Length \n");
+        for (int i = 0; i < contours.size(); i++) {
+            System.out.format(" * Contour[%d] - Area (M_00) = %.2f - Area OpenCV: %.2f - Length: %.2f\n", i,
+                    mu.get(i).m00, Imgproc.contourArea(contours.get(i)),
+                    Imgproc.arcLength(new MatOfPoint2f(contours.get(i).toArray()), true));
+        }
+        
+		return drawing;
+	}
+
+	@Override
+	public Set<Class<?>> allowedOperators() {
+		Set<Class<?>> allowed = new HashSet<>();
+		allowed.add(ReadImage.class);
+        allowed.add(WriteImage.class);
+        allowed.add(FindContours.class);
+        return allowed;
+	}
+	
+	public ArrayList<MatOfPoint>  getContoursList() {
+		return this.contours;
+	}
+	
+	public enum Information {
+        /**
+         * Operator information in string format.
+         */
+        OPERATOR_INFO {
+            /**
+             * @return - Operator information and name
+             * of the operator.
+             */
+            public String toString() {
+                return "Image Moments\n\n In Image processing, computer vision and related fields, "
+                		+ "an image moment is a certain particular weighted average of the image pixels' intensities, "
+                		+ "or a function of such moments, usually chosen to have some attractive property or interpreation."
+                		+ "Image moments are useful to describe objects after segmentation.";
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/imagelab/view/forms/ConvexHullPropertiesForm.java
+++ b/src/main/java/com/imagelab/view/forms/ConvexHullPropertiesForm.java
@@ -1,0 +1,24 @@
+package com.imagelab.view.forms;
+
+import com.imagelab.operator.imagecontours.ConvexHull;
+
+import javafx.scene.layout.VBox;
+
+public class ConvexHullPropertiesForm extends AbstractPropertiesForm{
+   public ConvexHullPropertiesForm(ConvexHull operator) {
+	     //Bounding Boxes for contours title container.
+		
+	     PropertiesFormTitleContainer ConvexHullTitleContainer;
+	     ConvexHullTitleContainer = new PropertiesFormTitleContainer("Convex Hull");
+	     
+	     VBox contoursPropertiesContainer = new VBox();
+	     contoursPropertiesContainer.setPrefSize(205, 47);
+	     contoursPropertiesContainer.setSpacing(20);
+	     contoursPropertiesContainer.setLayoutX(14);
+	     contoursPropertiesContainer.setLayoutY(14);
+	     contoursPropertiesContainer.getChildren().addAll(
+	    	ConvexHullTitleContainer
+	     );
+	     getChildren().addAll(contoursPropertiesContainer);
+   }
+}

--- a/src/main/java/com/imagelab/view/forms/FindContoursPropertiesForm.java
+++ b/src/main/java/com/imagelab/view/forms/FindContoursPropertiesForm.java
@@ -21,7 +21,7 @@ public class FindContoursPropertiesForm extends AbstractPropertiesForm{
        thresholdSliderContainer.setPrefWidth(205.0);
        thresholdSliderContainer.setSpacing(10);
        Label lblthresholdSlider = new Label("Canny Threshold :");
-       TextField boxthresholdTextField = new TextField(String.valueOf(1));
+       TextField boxthresholdTextField = new TextField(String.valueOf(100));
        boxthresholdTextField.setPrefSize(205.0, 27.0);
        
        Slider thresholdSlider = new Slider();

--- a/src/main/java/com/imagelab/view/forms/ImageMomentsPropertiesForm.java
+++ b/src/main/java/com/imagelab/view/forms/ImageMomentsPropertiesForm.java
@@ -1,0 +1,25 @@
+package com.imagelab.view.forms;
+
+import com.imagelab.operator.imagecontours.ImageMoments;
+
+import javafx.scene.layout.VBox;
+
+public class ImageMomentsPropertiesForm extends AbstractPropertiesForm {
+ public ImageMomentsPropertiesForm(ImageMoments operator) {
+	 //Bounding Boxes for contours title container.
+		
+     PropertiesFormTitleContainer ImageMomentTitleContainer;
+     ImageMomentTitleContainer = new PropertiesFormTitleContainer("Image Moments");
+     
+     VBox contoursPropertiesContainer = new VBox();
+     contoursPropertiesContainer.setPrefSize(205, 47);
+     contoursPropertiesContainer.setSpacing(20);
+     contoursPropertiesContainer.setLayoutX(14);
+     contoursPropertiesContainer.setLayoutY(14);
+     contoursPropertiesContainer.getChildren().addAll(
+     	ImageMomentTitleContainer
+     );
+     getChildren().addAll(contoursPropertiesContainer);
+	   
+ }
+}

--- a/src/main/resources/com/imagelab/style.css
+++ b/src/main/resources/com/imagelab/style.css
@@ -265,3 +265,15 @@
  	-fx-text-fill: white;
  	-fx-background-color:  linear-gradient(#3e6fdd 21%, #3ddb42 52%, #d61b31 84%);
 }
+/**
+ * Image Moments UI element styles */
+ #imageMoments{
+ 	-fx-background-color: #0C4956;
+    -fx-text-fill: white;
+ }
+ /**
+  * Convex Hull UI element styles */
+  #convexHull{
+  	-fx-background-color: #0D5C84;
+    -fx-text-fill: white;
+  }


### PR DESCRIPTION
# Description

This PR contains another vital two operators for the contour operations pane. 
1. Image moments - which output weighted average of pixel intensities and widely used describe objects after image segmentation
2. Convex Hull - which is a binary image with a set of pixels included in the smallest convex polygon surrounded all white pixels in the input.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
1. Manual Testing
Uses sample images to test the operators. inefficiencies reduce by the operator stream properties and tune the image according to the scenario included)

#### convex hull demo
![convex hull](https://user-images.githubusercontent.com/52147094/127760062-0fc79de6-e118-4d19-86ee-84d654c827b6.gif)
#### image moment demo
![image moments](https://user-images.githubusercontent.com/52147094/127760041-ff52ea74-047f-404f-bc42-3e2a48178ccf.gif)

#### image moment arc points 
![image](https://user-images.githubusercontent.com/52147094/127760047-e89af08e-47ba-4a6c-a802-2f190a2031e4.png)



