### PR TITLE
Undo and Redo functions are added.

### DIFF
--- a/src/main/java/com/imagelab/DashboardController.java
+++ b/src/main/java/com/imagelab/DashboardController.java
@@ -44,7 +44,7 @@ public class DashboardController implements Initializable {
     private final Stack<OperatorUIElement> appliedOperators;
 
     /**
-     * Queue which holds UI elements which are undone after adding to the playground
+     * Stack which holds UI elements which are undone after adding to the playground
      * dragged and dropped into the playground.
      */
     private final Stack<OperatorUIElement> undoOperators;

--- a/src/main/java/com/imagelab/DashboardController.java
+++ b/src/main/java/com/imagelab/DashboardController.java
@@ -44,6 +44,12 @@ public class DashboardController implements Initializable {
     private final Stack<OperatorUIElement> appliedOperators;
 
     /**
+     * Queue which holds UI elements which are undone after adding to the playground
+     * dragged and dropped into the playground.
+     */
+    private final Stack<OperatorUIElement> undoOperators;
+
+    /**
      * To capture the latest applied operator
      * to the playground.
      */
@@ -178,6 +184,7 @@ public class DashboardController implements Initializable {
      */
     public DashboardController() {
         this.appliedOperators = new Stack<>();
+        this.undoOperators = new Stack<>();
     }
 
     /**
@@ -246,6 +253,53 @@ public class DashboardController implements Initializable {
     }
 
     /**
+     * Method which undo the playground event
+     *
+     * @param actionEvent - onClick Mouse Event.
+     * @throws IOException - if the event was not captured.
+     */
+    @FXML
+    public void onUndoClicked(ActionEvent actionEvent) throws IOException {
+        if(!appliedOperators.empty()){
+            OperatorUIElement lastElem = this.appliedOperators.pop();
+            this.playgroundOpContainer.getChildren().remove(lastElem.element);
+            this.undoOperators.add(lastElem);
+            if(appliedOperators.isEmpty()){
+                this.playgroundAreaLabel.setVisible(true);
+                this.previewPane.getChildren().clear();
+                this.uiElementPropertiesPane.setContent(null);
+            }else{
+                OperatorUIElement lastOperation = this.appliedOperators.lastElement();
+                this.uiElementPropertiesPane.setContent(lastOperation.propertiesFormUI);
+                this.informationScrollPane.setContent(lastOperation.informationUI);
+
+            }
+
+        }
+    }
+
+
+    /**
+     * Method which undo the playground event
+     *
+     * @param actionEvent - onClick Mouse Event.
+     * @throws IOException - if the event was not captured.
+     */
+    @FXML
+    public void onRedoClicked(ActionEvent actionEvent) throws IOException {
+        if(!undoOperators.isEmpty()){
+            OperatorUIElement lastElem = undoOperators.pop();
+            if(appliedOperators.isEmpty()){
+                this.playgroundAreaLabel.setVisible(false);
+            }
+            this.appliedOperators.add(lastElem);
+            this.playgroundOpContainer.getChildren().add(lastElem.element);
+            this.uiElementPropertiesPane.setContent(lastElem.propertiesFormUI);
+            this.informationScrollPane.setContent(lastElem.informationUI);
+        }
+    }
+
+    /**
      * Method which reset the playground ones user
      * pressed on the refresh.
      *
@@ -264,6 +318,8 @@ public class DashboardController implements Initializable {
             if (reply.equals("OK")) {
                 // Removing all the elements from appliedOperators.
                 this.appliedOperators.clear();
+                // Removing all the elements from the undoOperators.
+                this.undoOperators.clear();
                 // Removing rendered output images.
                 this.previewPane.getChildren().clear();
                 // Removing elements from the operators container.
@@ -288,9 +344,14 @@ public class DashboardController implements Initializable {
                             + " pipeline",
                     Alert.AlertType.WARNING
             );
+            // Clearing the unoOperators stack
+            this.undoOperators.clear();
+
             System.err.println("ERROR: empty pipeline,"
                     + " nothing to be cleared.");
         }
+
+
     }
 
     /**
@@ -586,4 +647,6 @@ public class DashboardController implements Initializable {
          */
         playgroundAreaLabel.setVisible(true);
     }
+
+
 }

--- a/src/main/resources/com/imagelab/dashboard.fxml
+++ b/src/main/resources/com/imagelab/dashboard.fxml
@@ -289,6 +289,18 @@
                         <HBox fx:id="topToolbarContainer" alignment="CENTER_RIGHT" prefHeight="44.0" prefWidth="1005.0"
                               spacing="20.0" styleClass="topNavBar">
                             <children>
+                                <Button mnemonicParsing="false" onAction="#onUndoClicked" prefHeight="32.0"
+                                        prefWidth="117.0" text="Undo">
+                                    <opaqueInsets>
+                                        <Insets/>
+                                    </opaqueInsets>
+                                </Button>
+                                <Button mnemonicParsing="false" onAction="#onRedoClicked" prefHeight="32.0"
+                                        prefWidth="117.0" text="Redo">
+                                    <opaqueInsets>
+                                        <Insets/>
+                                    </opaqueInsets>
+                                </Button>
                                 <Button mnemonicParsing="false" onAction="#onResetClicked" prefHeight="32.0"
                                         prefWidth="117.0" text="Reset">
                                     <opaqueInsets>


### PR DESCRIPTION
# Description

Undo/Redo feature added for the image lab project. When the user added an operator to the playground he or she can remove it by pressing undo. And by pressing redo the user can add it again to the playground.
- Fixes #96 
- Feature #96 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

# Testing
Manual testing is done. 

![image](https://user-images.githubusercontent.com/59884818/158295765-0100c85f-d758-4a92-a23f-8cf0e258680e.png)

![image](https://user-images.githubusercontent.com/59884818/158295798-a5e695a6-eac7-4bf4-9f68-485081362545.png)

## When undo pressed after adding two operators to the playground
![image](https://user-images.githubusercontent.com/59884818/158295815-6f2e633d-59ae-4177-b2d0-2d1c61af6f73.png)

## When the redo pressed
![image](https://user-images.githubusercontent.com/59884818/158295833-e574cbf1-a431-4130-9dac-d472bcdecaff.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
