### PR TITLE
Drawing functions are refined

### DIFF
--- a/imagelab_electron/imagelab-blocks.js
+++ b/imagelab_electron/imagelab-blocks.js
@@ -280,7 +280,6 @@ Blockly.defineBlocksWithJsonArray([
         name: "thickness",
         value: 2,
         min: 1,
-        max: 100,
       },
       {
         type: "input_dummy",
@@ -341,6 +340,7 @@ Blockly.defineBlocksWithJsonArray([
         name: "thickness",
         value: 2,
         check: "point_block",
+        min: 1,
       },
       {
         type: "field_number",
@@ -384,7 +384,6 @@ Blockly.defineBlocksWithJsonArray([
         name: "thickness",
         value: 2,
         min: 1,
-        max: 100,
       },
       {
         type: "input_dummy",
@@ -394,7 +393,6 @@ Blockly.defineBlocksWithJsonArray([
         name: "radius",
         value: 5,
         min: 1,
-        max: 300,
       },
       {
         type: "input_dummy",
@@ -435,7 +433,6 @@ Blockly.defineBlocksWithJsonArray([
         name: "thickness",
         value: 2,
         min: 1,
-        max: 100,
       },
       {
         type: "input_dummy",
@@ -445,14 +442,12 @@ Blockly.defineBlocksWithJsonArray([
         name: "height",
         value: 0,
         min: 0,
-        max: 400,
       },
       {
         type: "field_number",
         name: "width",
         value: 0,
         min: 0,
-        max: 400,
       },
       {
         type: "field_angle",
@@ -501,7 +496,6 @@ Blockly.defineBlocksWithJsonArray([
         name: "thickness",
         value: 2,
         min: 1,
-        max: 100,
       },
       {
         type: "input_dummy",
@@ -560,7 +554,6 @@ Blockly.defineBlocksWithJsonArray([
         name: "thickness",
         value: 2,
         min: 1,
-        max: 100,
       },
       {
         type: "input_dummy",
@@ -570,7 +563,6 @@ Blockly.defineBlocksWithJsonArray([
         name: "scale",
         value: 1,
         min: 1,
-        max: 100,
       },
       {
         type: "input_dummy",
@@ -599,96 +591,6 @@ Blockly.defineBlocksWithJsonArray([
     colour: 240,
     tooltip:
       "You can write a text on the image and dedicate its thickness, scale, color and start point.",
-    helpUrl: "",
-  },
-  {
-    type: "rgb_block",
-    message0: "%1 Red %2 %3 %4 Green %5 %6 %7 Blue %8",
-    args0: [
-      {
-        type: "field_image",
-        src: "https://github.com/polahano/Git_Test/blob/main/icons8-filled-circle-30.png?raw=true",
-        width: 20,
-        height: 20,
-        alt: "*",
-        flipRtl: false,
-      },
-      {
-        type: "field_number",
-        name: "R",
-        value: 50,
-        min: 0,
-        max: 250,
-      },
-      {
-        type: "input_dummy",
-      },
-      {
-        type: "field_image",
-        src: "https://github.com/polahano/Git_Test/blob/main/icons8-filled-circle-30%20(2).png?raw=true",
-        width: 20,
-        height: 20,
-        alt: "*",
-        flipRtl: false,
-      },
-      {
-        type: "field_number",
-        name: "G",
-        value: 50,
-        min: 0,
-        max: 250,
-      },
-      {
-        type: "input_dummy",
-      },
-      {
-        type: "field_image",
-        src: "https://github.com/polahano/Git_Test/blob/main/icons8-filled-circle-30%20(1).png?raw=true",
-        width: 20,
-        height: 20,
-        alt: "*",
-        flipRtl: false,
-      },
-      {
-        type: "field_number",
-        name: "B",
-        value: 50,
-        min: 0,
-        max: 250,
-      },
-    ],
-    inputsInline: false,
-    output: "rgb_block",
-    colour: 240,
-    tooltip: "",
-    helpUrl: "",
-  },
-  {
-    type: "point_block",
-    message0: "Point ( %1 %2 , %3 )",
-    args0: [
-      {
-        type: "field_number",
-        name: "pointX",
-        value: 0,
-        min: -400,
-        max: 350,
-      },
-      {
-        type: "input_dummy",
-      },
-      {
-        type: "field_number",
-        name: "pointY",
-        value: 0,
-        min: -400,
-        max: 350,
-      },
-    ],
-    inputsInline: true,
-    output: "point_block",
-    colour: 240,
-    tooltip: "",
     helpUrl: "",
   },
 

--- a/imagelab_electron/index.html
+++ b/imagelab_electron/index.html
@@ -123,10 +123,8 @@
                   <block type="drawingoperations_drawellipse"></block>
                   <block type="drawingoperations_drawarrowline"></block>
                   <block type="drawingoperations_drawtext"></block>
-                  <block type="rgb_block"></block>
                   <block type="drawingoperations_drawcircle"></block>
                   <block type="drawingoperations_drawrectangle"></block>
-                  <block type="point_block"></block>
                 </category>
                 <category
                   css-icon="customIcon mdi mdi-blur"

--- a/imagelab_electron/src/helpers/convertColor.js
+++ b/imagelab_electron/src/helpers/convertColor.js
@@ -1,3 +1,9 @@
+/**
+ * This function is responsible for generating r,g,b values
+ * for a hexadecimal color string
+ * @param {string} hex
+ * @returns object
+ */
 function hexToRgb(hex) {
   var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
   return result

--- a/imagelab_electron/src/operator/basic/ReadImage.js
+++ b/imagelab_electron/src/operator/basic/ReadImage.js
@@ -10,7 +10,7 @@ class ReadImage extends OpenCvOperator {
 
   /**
    * This function reads the given image
-   * @param {Location of the image which need to read} imageURL
+   * @param {string} imageURL
    * @returns processed image
    */
   compute(image) {

--- a/imagelab_electron/src/operator/basic/WriteImage.js
+++ b/imagelab_electron/src/operator/basic/WriteImage.js
@@ -5,8 +5,6 @@ const OpenCvOperator = require("../OpenCvOperator");
  * processed image.
  */
 class WriteImage extends OpenCvOperator {
-  #outImageUrl = __dirname + "/proccesedimage.jpg";
-
   constructor(type) {
     super(type);
   }
@@ -14,7 +12,7 @@ class WriteImage extends OpenCvOperator {
   /**
    * This function writes a processed image to the path given
    * And save the image in the location that the user specified
-   * @param {Processed image to write} processedImage
+   * @param {Mat} processedImage
    */
   compute(processedImage) {
     const preview = document.getElementById("image-preview");

--- a/imagelab_electron/src/operator/drawing/DrawArrowLine.js
+++ b/imagelab_electron/src/operator/drawing/DrawArrowLine.js
@@ -1,6 +1,10 @@
-const { hexToRgb } = require("../../helpers/convertColor");
 const OpenCvOperator = require("../OpenCvOperator");
+const { hexToRgb } = require("../../helpers/convertColor");
 
+/**
+ * This function contains the main logic
+ * to draw an arrowed line on the image
+ */
 class DrawArrowLine extends OpenCvOperator {
   #lineColor = { r: 40, g: 40, b: 240 };
   #thickness = 2;
@@ -29,15 +33,7 @@ class DrawArrowLine extends OpenCvOperator {
   }
 
   compute(image) {
-    let p1 = new this.cv2.Point(this.#startingPointX, this.#startingPointY);
-    let p2 = new this.cv2.Point(this.#endingPointX, this.#endingPointY);
-    this.cv2.arrowedLine(
-      image,
-      p1,
-      p2,
-      [this.#lineColor.r, this.#lineColor.g, this.#lineColor.b, 255],
-      this.#thickness
-    );
+    // There is no function in opencv.js to draw an arrowed line
     return image;
   }
 }

--- a/imagelab_electron/src/operator/drawing/DrawCircle.js
+++ b/imagelab_electron/src/operator/drawing/DrawCircle.js
@@ -1,6 +1,10 @@
-const { hexToRgb } = require("../../helpers/convertColor");
 const OpenCvOperator = require("../OpenCvOperator");
+const { hexToRgb } = require("../../helpers/convertColor");
 
+/**
+ * This functions contains the main logic of
+ * drawing a circle inside the input image
+ */
 class DrawCircle extends OpenCvOperator {
   #thickness = 2;
   #radius = 5;
@@ -25,9 +29,15 @@ class DrawCircle extends OpenCvOperator {
     }
   }
 
+  /**
+   * This function is responsible for drawing a circle
+   * in the input image according to the given inputs
+   * @param {Mat} image
+   * @returns {Mat}
+   */
   compute(image) {
     let p1 = new this.cv2.Point(this.#centerPointX, this.#centerPointY);
-    image = this.cv2.circle(
+    this.cv2.circle(
       image,
       p1,
       this.#radius,

--- a/imagelab_electron/src/operator/drawing/DrawEllipse.js
+++ b/imagelab_electron/src/operator/drawing/DrawEllipse.js
@@ -1,6 +1,10 @@
-const { hexToRgb } = require("../../helpers/convertColor");
 const OpenCvOperator = require("../OpenCvOperator");
+const { hexToRgb } = require("../../helpers/convertColor");
 
+/**
+ * This class contains the main logic to draw an ellipse
+ * On the input image
+ */
 class DrawEllipse extends OpenCvOperator {
   #thickness = 2;
   #height = 5;
@@ -9,11 +13,12 @@ class DrawEllipse extends OpenCvOperator {
   #centerPointY = 0;
   #ellipseColor = { r: 40, g: 40, b: 240 };
   #angle = 90;
+
   constructor(type) {
     super(type);
   }
 
-  setTypes(param, value) {
+  setParams(param, value) {
     if (param === "thickness") {
       this.#thickness = value;
     } else if (param === "height") {
@@ -31,12 +36,19 @@ class DrawEllipse extends OpenCvOperator {
     }
   }
 
+  /**
+   * This function get the mat image and
+   * draw an ellipse according to the given inputs
+   * @param {Mat} image
+   * @returns {Mat}
+   */
   compute(image) {
     let p1 = new this.cv2.Point(this.#centerPointX, this.#centerPointY);
+    let s1 = new this.cv2.Size(this.#height, this.#width);
     this.cv2.ellipse(
       image,
       p1,
-      [this.#height, this.#width],
+      s1,
       this.#angle,
       0,
       360,

--- a/imagelab_electron/src/operator/drawing/DrawLine.js
+++ b/imagelab_electron/src/operator/drawing/DrawLine.js
@@ -1,6 +1,10 @@
 const { hexToRgb } = require("../../helpers/convertColor");
 const OpenCvOperator = require("../OpenCvOperator");
 
+/**
+ * This class contains all the logic regarding with
+ * drawing a line in the input image
+ */
 class DrawLine extends OpenCvOperator {
   #thickNess = 2;
   #lineColor = { r: 40, g: 40, b: 240 };
@@ -28,6 +32,12 @@ class DrawLine extends OpenCvOperator {
     }
   }
 
+  /**
+   * This function draw line on the input image
+   * according to the inputs given by the user
+   * @param {Mat} image
+   * @returns
+   */
   compute(image) {
     let p1 = new this.cv2.Point(this.#point_x1, this.#point_y1);
     let p2 = new this.cv2.Point(this.#point_x2, this.#point_y2);

--- a/imagelab_electron/src/operator/drawing/DrawRectangle.js
+++ b/imagelab_electron/src/operator/drawing/DrawRectangle.js
@@ -1,6 +1,10 @@
-const { hexToRgb } = require("../../helpers/convertColor");
 const OpenCvOperator = require("../OpenCvOperator");
+const { hexToRgb } = require("../../helpers/convertColor");
 
+/**
+ * This function contains the main logic of
+ * drawing a rectangle inside the input image
+ */
 class DrawRectangle extends OpenCvOperator {
   #startPointX = 0;
   #startPointY = 0;
@@ -29,10 +33,16 @@ class DrawRectangle extends OpenCvOperator {
     }
   }
 
+  /**
+   * This function draws a rectangle in the input image
+   * according to the inputs given by the user
+   * @param {Mat} image
+   * @returns
+   */
   compute(image) {
     let p1 = new this.cv2.Point(this.#startPointX, this.#startPointY);
     let p2 = new this.cv2.Point(this.#endPointX, this.#endPointY);
-    image = this.cv2.rectangle(
+    this.cv2.rectangle(
       image,
       p1,
       p2,

--- a/imagelab_electron/src/operator/drawing/DrawText.js
+++ b/imagelab_electron/src/operator/drawing/DrawText.js
@@ -1,6 +1,10 @@
-const { hexToRgb } = require("../../helpers/convertColor");
 const OpenCvOperator = require("../OpenCvOperator");
+const { hexToRgb } = require("../../helpers/convertColor");
 
+/**
+ * This class includes the main logic of
+ * putting the text over an input image
+ */
 class DrawText extends OpenCvOperator {
   #text = "Image Lab";
   #thickness = 2;
@@ -8,10 +12,10 @@ class DrawText extends OpenCvOperator {
   #textColor = { r: 40, g: 40, b: 240 };
   #pointX = 0;
   #pointY = 0;
+
   constructor(type) {
     super(type);
   }
-
   setParams(param, value) {
     if (param === "draw_text") {
       this.#text = value;
@@ -28,15 +32,22 @@ class DrawText extends OpenCvOperator {
     }
   }
 
+  /**
+   * This function draws the text over the input
+   * image according to the inputted values
+   * @param {Mat} image
+   * @returns {Mat}
+   */
   compute(image) {
     let p1 = new this.cv2.Point(this.#pointX, this.#pointY);
-    font = this.cv2.FONT_HERSHEY_SIMPLEX;
-    image = this.cv2.putText(
+    const font = this.cv2.FONT_HERSHEY_SIMPLEX;
+    this.cv2.putText(
       image,
       this.#text,
+      p1,
       font,
       this.#scale,
-      [this.#textColor.r, this.#textColor.g, this.#textColor.b, 0],
+      [this.#textColor.r, this.#textColor.g, this.#textColor.b, 255],
       this.#thickness,
       this.cv2.LINE_AA
     );


### PR DESCRIPTION
# Description

Previously from the drawing functions, only the draw line worked correctly. 
By this PR the refined operations are,
- Draw Ellipse
- Draw Circle
- Put Text
- Draw Rectangle

Therefore now in the drawings section the working operations are,
- Draw Line
- Draw Ellipse
- Draw Circle
- Put Text
- Draw Rectangle

In opencv.js there is no any operation to draw an arrowed line. Therefore that function do not operates. If there is a different way of implementing it, the developer only needs to implement the functionality in it. All the other connections are implemented successfully for the draw arrowed line operation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual Testing

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

Also, include screenshots for verification and reviewing purpose.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
