### PR TITLE
added image download button

### DIFF
--- a/imagelab_electron/index.html
+++ b/imagelab_electron/index.html
@@ -233,6 +233,16 @@
                       vertical-align: super;
                     "
                   ></span>
+                  <span
+                    onclick="downloadImage()"
+                    title="Download"
+                    class="mdi mdi-download"
+                    style="
+                      font-size: 30px;
+                      color: #000000;
+                      vertical-align: super;
+                    "
+                  ></span>
                   <p style="margin-bottom: 0px; margin-top: 8px">Preview</p>
                   <span
                     class="mdi mdi-replay"

--- a/imagelab_electron/src/operator/basic/WriteImage.js
+++ b/imagelab_electron/src/operator/basic/WriteImage.js
@@ -19,10 +19,6 @@ class WriteImage extends OpenCvOperator {
   compute(processedImage) {
     const preview = document.getElementById("image-preview");
     this.cv2.imshow(preview, processedImage);
-    var link = document.createElement("a");
-    link.download = "Processed_image.jpg";
-    link.href = preview.toDataURL();
-    link.click();
   }
 }
 

--- a/imagelab_electron/workspace.js
+++ b/imagelab_electron/workspace.js
@@ -153,6 +153,18 @@ function executeProcess() {
 }
 
 /**
+ * This function is responsible for downloading the output image
+ * to the user's local machine
+ */
+function downloadImage() {
+  const preview = document.getElementById("image-preview");
+  var link = document.createElement("a");
+  link.download = "Processed_image.jpg";
+  link.href = preview.toDataURL();
+  link.click();
+}
+
+/**
  * This function is responsible for setting the location of the output image
  */
 function setDirectory() {


### PR DESCRIPTION
# Description

This pull request addresses the issue of repetitive download window pop-ups when the execute command is clicked. Instead of that, I added a download button with an icon and integrated the image download operation with it.
- Feature #118 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Manually tested

https://user-images.githubusercontent.com/39716499/224478759-bac3cafa-1d65-4c20-9800-6ba3c487ee5f.mp4

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
