### PR TITLE
Added a confirm dialog before resetWorkspace

### DIFF
--- a/imagelab_electron/workspace.js
+++ b/imagelab_electron/workspace.js
@@ -164,8 +164,20 @@ function setDirectory() {
 }
 
 function resetWorkspace() {
-  workspace.clear();
-  mainController.resetTheWorkpace();
+  //Prompt the user to confirm the action
+  dialog.showMessageBox(null, {
+    title: "Caution!",
+
+    buttons: ["Cancel", "Reset"],
+    type: "warning",
+    message: "Please note that resetting the workspace will result in the loss of all unsaved work.",
+  }).then(result => {
+    if (result.response === 1) {
+      //Reset the workspace
+      workspace.clear();
+      mainController.resetTheWorkpace();
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
# Description

By clicking the reset button, all the work in the workspace was instantly removed. I have added a confirm alert to confirm the action from the user and only then execute the reset operation

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

Also, include screenshots for verification and reviewing purpose.

https://user-images.githubusercontent.com/19731056/224732065-3ab2e468-5574-47a6-80b3-88558cdabd9b.mp4


# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
