### PR TITLE
added gray image operation

### DIFF
--- a/imagelab_electron/operations.js
+++ b/imagelab_electron/operations.js
@@ -5,6 +5,7 @@ const PROCESS_OPERATIONS = {
   ROTATEIMAGE: "geometric_rotateimage",
   AFFINEIMAGE: "geometric_affineimage",
   SCALEIMAGE: "geometric_scaleimage",
+  GRAYIMAGE:"imageconvertions_grayimage",
   DRAWLINE: "drawingoperations_drawline",
   DRAWELLIPSE: "drawingoperations_drawellipse",
   DRAWARROWLINE: "drawingoperations_drawarrowline",

--- a/imagelab_electron/src/controller/main.js
+++ b/imagelab_electron/src/controller/main.js
@@ -1,6 +1,7 @@
 const PROCESS_OPERATIONS = require("../../operations");
 const ReadImage = require("../operator/basic/ReadImage");
 const WriteImage = require("../operator/basic/WriteImage");
+const GrayImage = require("../operator/convertions/GrayImage");
 const Blur = require("../operator/blurring/Blur");
 const GaussianBlur = require("../operator/blurring/GaussianBlur");
 const MedianBlur = require("../operator/blurring/MedianBlur");
@@ -109,6 +110,11 @@ class MainController {
       case PROCESS_OPERATIONS.WRITEIMAGE:
         this.#appliedOperators.push(
           new WriteImage(PROCESS_OPERATIONS.WRITEIMAGE, id)
+        );
+        break;
+      case PROCESS_OPERATIONS.GRAYIMAGE:
+        this.#appliedOperators.push(
+          new GrayImage(PROCESS_OPERATIONS.GRAYIMAGE, id)
         );
         break;
       case PROCESS_OPERATIONS.REFLECTIMAGE:

--- a/imagelab_electron/src/operator/convertions/GrayImage.js
+++ b/imagelab_electron/src/operator/convertions/GrayImage.js
@@ -1,0 +1,23 @@
+const OpenCvOperator = require("../OpenCvOperator");
+
+/**
+ * This class contains the main logic to gray the image
+ */
+class GrayImage extends OpenCvOperator {
+  constructor(type, id) {
+    super(type, id);
+  }
+
+  /**
+   * @param {Mat} image
+   * @returns
+   * This function grays the image
+   */
+  compute(image) {
+    let dst = new this.cv2.Mat();
+    this.cv2.cvtColor(image, dst, this.cv2.COLOR_BGR2GRAY);
+    return dst;
+  }
+}
+
+module.exports = GrayImage;


### PR DESCRIPTION
# Description

Added functionality to gray an image. Now the "gray the image" block under the convertions section can be used to gray an image.
- Feature #135 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Tested manually

![image](https://user-images.githubusercontent.com/39716499/226195418-fdffa8c8-9b35-491b-b95c-3c1ef0af7bac.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
