### PR TITLE
Add: Image viewer zoom in/out feature

### DIFF
--- a/imagelab_react/package.json
+++ b/imagelab_react/package.json
@@ -19,6 +19,7 @@
     "react-blockly": "^7.2.2",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
+    "react-zoom-pan-pinch": "^3.1.0",
     "sharp": "^0.32.1",
     "web-vitals": "^2.1.4"
   },

--- a/imagelab_react/src/components/ImageViewer.js
+++ b/imagelab_react/src/components/ImageViewer.js
@@ -1,14 +1,57 @@
-import React from 'react';
-import { Icon } from '@blueprintjs/core';
+import React, { useState } from 'react';
+import { Icon, Button, ButtonGroup } from '@blueprintjs/core';
+import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch';
 
 const ImageViewer = ({ imageUrl }) => {
+  const [initialScale, setInitialScale] = useState(1);
+
+  const handleImageLoad = ({ target: img }) => {
+    const imageWidth = img.naturalWidth;
+    const imageHeight = img.naturalHeight;
+
+    const viewerWidth = img.parentNode.clientWidth;
+    const viewerHeight = img.parentNode.clientHeight;
+
+    const scaleX = viewerWidth / imageWidth;
+    const scaleY = viewerHeight / imageHeight;
+
+    setInitialScale(Math.max(scaleX, scaleY));
+  };
+
   return (
-    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-        {imageUrl ? (
-          <img src={imageUrl} alt="Image" style={{ maxWidth: '100%', maxHeight: '100%' }} />
-        ) : (
-          <Icon icon="media" size={100} />
-        )}
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', position: 'relative', width: '100%', height: '250px', overflow: 'hidden' }}>
+      {imageUrl ? (
+        <TransformWrapper
+          initialScale={initialScale}
+          defaultPositionX={0}
+          defaultPositionY={0}
+          minScale={0.1}
+          limitToBounds={true}
+          boundSize={{ width: 1.25, height: 1.25 }}
+          boundPosition={{ x: -0.125, y: -0.125 }}
+        >
+          {({ zoomIn, zoomOut, resetTransform, ...rest }) => (
+            <React.Fragment>
+              <div className='tools' style={{ position: 'absolute', zIndex: 1, right: 0, top: 0 }}>
+                <ButtonGroup>
+                  <Button icon="zoom-in" onClick={() => zoomIn()} />
+                  <Button icon="zoom-out" onClick={() => zoomOut()} />
+                  <Button icon="zoom-to-fit" onClick={() => resetTransform()} />
+                </ButtonGroup>
+              </div>
+              <TransformComponent>
+                <img 
+                  src={imageUrl} 
+                  alt="Image" 
+                  onLoad={handleImageLoad} 
+                />
+              </TransformComponent>
+            </React.Fragment>
+          )}
+        </TransformWrapper>
+      ) : (
+        <Icon icon="media" size={100} />
+      )}
     </div>
   );
 };

--- a/imagelab_react/yarn.lock
+++ b/imagelab_react/yarn.lock
@@ -8958,6 +8958,11 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-zoom-pan-pinch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.1.0.tgz#d87a66fd22a97f5dd56b54076411a9dce1f448cd"
+  integrity sha512-a3LlP8QPgTikvteCNkZ3X6wIWC0lrg1geP5WkUJyx2MXXAhHQek3r17N1nT/esOiWGuPIECnsd9AGoK8jOeGcg==
+
 react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"


### PR DESCRIPTION
# Description
The image viewer now supports zoom capabilities. Earlier, the entire component would expand to accommodate the image. Now, it remains a fixed size, giving the user the ability to zoom and pinch on the image

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

Also, include screenshots for verification and reviewing purpose.

https://github.com/scorelab/imagelab/assets/19731056/aed30bd7-5555-4c5c-ac82-4e399316f4ee

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
