### PR TITLE
[Image Lab React]:Added preload scripts to use ipcRenderer.

### DIFF
--- a/imagelab_react/public/electron.js
+++ b/imagelab_react/public/electron.js
@@ -13,6 +13,7 @@ function createWindow() {
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false,
+      preload: path.join(__dirname, 'preload.js'),
     },
   });
 

--- a/imagelab_react/public/preload.js
+++ b/imagelab_react/public/preload.js
@@ -1,0 +1,2 @@
+const electron = require('electron');
+window.ipcRenderer = electron.ipcRenderer;

--- a/imagelab_react/src/browse-blocks-functions.js
+++ b/imagelab_react/src/browse-blocks-functions.js
@@ -1,6 +1,5 @@
 import Blockly from "blockly";
-const electron = window.require('electron');
-const ipcRenderer  = electron.ipcRenderer;
+const ipcRenderer = window.ipcRenderer;
 
 /*This function is responible for opening file selector window to choose the picture you will do operqations on 
 it works with (read image) block */

--- a/imagelab_react/src/utils/main.js
+++ b/imagelab_react/src/utils/main.js
@@ -1,6 +1,5 @@
 import Blockly from "blockly";
-const electron = window.require('electron');
-const ipcRenderer  = electron.ipcRenderer;
+const ipcRenderer = window.ipcRenderer;
 
 function processBlock(block, pipeline) {
     const blockParams = block.inputList.reduce((params, input) => {


### PR DESCRIPTION
# Description

I have added preload scripts to fix the error `window.require is not a function.`
The preload script initialize the renderer process  environment i.e,`ipcRenderer` before the actual web page content is loaded.

- Fixes #177 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

Initially it was giving this error,

![require2](https://github.com/scorelab/imagelab/assets/107514366/0164b08d-9c84-4208-97d4-fe84bc8ce9e4)

After adding preload scripts,

![resolved](https://github.com/scorelab/imagelab/assets/107514366/9ef6713a-d085-4021-9157-5d5310b7e81d)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
