### PR TITLE
Resolved the UI bug of Operator Description overlap #182

### DIFF
--- a/imagelab_electron/index.html
+++ b/imagelab_electron/index.html
@@ -179,11 +179,11 @@
             </div>
           </div>
           <div class="information-pane" id="information-pane">
-            <p style="font-size: 15px; margin-top: 5px" id="operator_name">
+            <p style="font-size: 15px; margin-top: 5px; margin-bottom: auto;" id="operator_name">
               Operation name
             </p>
             <p
-              style="font-size: 13px; line-height: 2px"
+              style="font-size: 12px; line-height: inherit;margin-top: auto;"
               id="operator_description"
             >
               here is the operation description

--- a/imagelab_electron/styles/style.css
+++ b/imagelab_electron/styles/style.css
@@ -85,7 +85,6 @@ body {
 .information-pane {
   width: auto;
   min-width: 700px;
-  height: 7vh;
   margin-top: 7px;
   padding-left: 15px;
   padding-top: 3px;


### PR DESCRIPTION
# Description

Made style changes to beautify information pane that resolves issue #182 
- overlaping of operator Description #182
- Dynamic height of information pane #182

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've thoroughly tested the drag-and-drop functionality across all UI blocks by manually dragging each block. To confirm this fix, I've attached screenshots showcasing the information plane of several blocks. You can be confident that this solution works consistently for all blocks.
![breakdown](https://github.com/scorelab/imagelab/assets/26256895/fad581c2-3e70-45a6-8f6c-3e1803968abb)
![Screenshot 2024-03-07 233057](https://github.com/scorelab/imagelab/assets/26256895/271d338b-4fdc-4705-8f60-f9e07caaf5c3)
![Screenshot 2024-03-07 233212](https://github.com/scorelab/imagelab/assets/26256895/7f5e27eb-3916-4f74-9650-dba4b4714215)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
